### PR TITLE
return the $false variable, not the reserved keyword false

### DIFF
--- a/wp_autoupdate.php
+++ b/wp_autoupdate.php
@@ -89,7 +89,7 @@ class wp_auto_update
             $information = $this->getRemote_information();
             return $information;
         }
-        return false;
+        return $false;
     }
 
     /**


### PR DESCRIPTION
The change allows multiple plugins with private repos to coexist as Wordpress stores the return information from previous checks into that variable