### PR TITLE
Update wp_autoupdate.php

### DIFF
--- a/wp_autoupdate.php
+++ b/wp_autoupdate.php
@@ -87,6 +87,7 @@ if( !class_exists( 'wp_auto_update' ) ) {
 				$obj->slug = $this->slug;
 				$obj->new_version = $remote_version->new_version;
 				$obj->url = $remote_version->url;
+				$obj->plugin = $this->plugin_slug;
 				$obj->package = $remote_version->package;
 				$transient->response[$this->plugin_slug] = $obj;
 			}


### PR DESCRIPTION
WP 4.2 needs the _plugin_ property for the [is_plugin_active check](https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/update.php#L281).