### PR TITLE
Add WordPress 'tested' to transient

### DIFF
--- a/wp_autoupdate.php
+++ b/wp_autoupdate.php
@@ -89,6 +89,7 @@ class WP_AutoUpdate
 			$obj->url = $remote_version->url;
 			$obj->plugin = $this->plugin_slug;
 			$obj->package = $remote_version->package;
+			$obj->tested = $remote_version->tested;
 			$transient->response[$this->plugin_slug] = $obj;
 		}
 		return $transient;


### PR DESCRIPTION
There are a couple more fields that could be added to the example.

However, tested is part of the information specifically provided in the update.php that is not passed on to WordPress.

Without this addition, WordPress doesn't know what version the author claims compatibility with.

It turns out that 'compatibility' is an added field that isn't used in this example.