### PR TITLE
Update wp_autoupdate.php

### DIFF
--- a/wp_autoupdate.php
+++ b/wp_autoupdate.php
@@ -103,13 +103,14 @@ class WP_AutoUpdate
 	 * @param object $arg
 	 * @return bool|object
 	 */
-	public function check_info($false, $action, $arg)
+	public function check_info($obj, $action, $arg)
 	{
-		if (isset($arg->slug) && $arg->slug === $this->slug) {
+		if (($action=='query_plugins' || $action=='plugin_information') && 
+		    isset($arg->slug) && $arg->slug === $this->slug) {
 			return $this->getRemote('info');
 		}
 		
-		return false;
+		return $obj;
 	}
 
 	/**


### PR DESCRIPTION
check_info() is a filter.
When "filtering" other plugins, it should not return FALSE, but original object/array.
In addition, make it return our obj only on limited actions, as described in codex.
